### PR TITLE
Swift5 conversion

### DIFF
--- a/Salesforce Org Setup/force-app/main/default/layouts/Case-Case Layout.layout-meta.xml
+++ b/Salesforce Org Setup/force-app/main/default/layouts/Case-Case Layout.layout-meta.xml
@@ -221,9 +221,6 @@
             <quickActionName>Case.LogACall</quickActionName>
         </quickActionListItems>
         <quickActionListItems>
-            <quickActionName>Case.CaseComment</quickActionName>
-        </quickActionListItems>
-        <quickActionListItems>
             <quickActionName>Case.ChangeStatus</quickActionName>
         </quickActionListItems>
         <quickActionListItems>

--- a/TrailInsurance.xcodeproj/project.pbxproj
+++ b/TrailInsurance.xcodeproj/project.pbxproj
@@ -382,12 +382,12 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0710;
-				LastUpgradeCheck = 0940;
+				LastUpgradeCheck = 1020;
 				ORGANIZATIONNAME = Salesforce;
 				TargetAttributes = {
 					4FD6C4731B754AF1002F9F90 = {
 						CreatedOnToolsVersion = 6.4;
-						LastSwiftMigration = 0900;
+						LastSwiftMigration = 1020;
 						SystemCapabilities = {
 							com.apple.Keychain = {
 								enabled = 1;
@@ -401,6 +401,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 				Base,
 			);
@@ -594,6 +595,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
@@ -651,6 +653,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
@@ -708,8 +711,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.force.trailinsurance.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -724,8 +726,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.force.trailinsurance.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};

--- a/TrailInsurance.xcodeproj/xcshareddata/xcschemes/TrailInsurance.xcscheme
+++ b/TrailInsurance.xcodeproj/xcshareddata/xcschemes/TrailInsurance.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0940"
+   LastUpgradeVersion = "1020"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/TrailInsurance/AppDelegate.swift
+++ b/TrailInsurance/AppDelegate.swift
@@ -43,7 +43,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
 	// MARK: - App delegate lifecycle
 
-	func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
+	func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
 		self.window = UIWindow(frame: UIScreen.main.bounds)
 		SFPushNotificationManager.sharedInstance().registerForRemoteNotifications()
 
@@ -76,7 +76,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 		// Respond to any push notification registration errors here.
 	}
 
-	func application(_ app: UIApplication, open url: URL, options: [UIApplicationOpenURLOptionsKey: Any] = [:]) -> Bool {
+	func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey: Any] = [:]) -> Bool {
 		// Uncomment following block to enable IDP Login flow
 		// return  UserAccountManager.sharedInstance().handleIDPAuthenticationResponse(url, options: options)
 		return false

--- a/TrailInsurance/Main.storyboard
+++ b/TrailInsurance/Main.storyboard
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="X3f-2E-ppv">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="X3f-2E-ppv">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="Stack View standard spacing" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -54,6 +54,11 @@
                         </connections>
                     </tableView>
                     <navigationItem key="navigationItem" title="Open Claims" id="ZGK-T4-rWJ">
+                        <barButtonItem key="leftBarButtonItem" title="Logout" id="deX-ox-UB2">
+                            <connections>
+                                <action selector="logout:" destination="UHa-EE-CUE" id="2vo-3F-Nfp"/>
+                            </connections>
+                        </barButtonItem>
                         <barButtonItem key="rightBarButtonItem" systemItem="add" id="QOR-Dm-Qp6">
                             <connections>
                                 <segue destination="HsS-mH-qOu" kind="presentation" modalPresentationStyle="formSheet" id="as3-Z9-jzM"/>

--- a/TrailInsurance/NewClaimViewController+Map.swift
+++ b/TrailInsurance/NewClaimViewController+Map.swift
@@ -49,7 +49,7 @@ extension NewClaimViewController {
 	}
 
     private func centerMap(on location: CLLocation) {
-			let coordinateRegion = MKCoordinateRegionMakeWithDistance(location.coordinate, regionRadius, regionRadius)
+			let coordinateRegion = MKCoordinateRegion.init(center: location.coordinate, latitudinalMeters: regionRadius, longitudinalMeters: regionRadius)
 			mapView.setRegion(coordinateRegion, animated: true)
 		geocode(location)
     }

--- a/TrailInsurance/NewClaimViewController+Photos.swift
+++ b/TrailInsurance/NewClaimViewController+Photos.swift
@@ -81,11 +81,11 @@ extension NewClaimViewController {
 extension NewClaimViewController: UINavigationControllerDelegate {}
 
 extension NewClaimViewController: UIImagePickerControllerDelegate {
-    func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [String: Any]) {
-        imagePickerCtrl.dismiss(animated: true, completion: nil)
-        if let image = info[UIImagePickerControllerOriginalImage] as? UIImage {
-            selectedImages.append(image)
+	func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey: Any]) {
+		imagePickerCtrl.dismiss(animated: true, completion: nil)
+		if let image = info[.originalImage] as? UIImage {
+			selectedImages.append(image)
 			addToPhotoStack(image)
-        }
-    }
+		}
+	}
 }

--- a/TrailInsurance/NewClaimViewController+Recording.swift
+++ b/TrailInsurance/NewClaimViewController+Recording.swift
@@ -20,6 +20,7 @@ extension NewClaimViewController: AVAudioRecorderDelegate, AVAudioPlayerDelegate
 	}
 
 	func initAVRecordingExtension() {
+//		var rs: AVAudioSession!
 		recordingSession = AVAudioSession.sharedInstance()
 		playButton.isEnabled = false
 
@@ -29,10 +30,10 @@ extension NewClaimViewController: AVAudioRecorderDelegate, AVAudioPlayerDelegate
 		transcriptionTextView.layer.cornerRadius = 6
 
 		do {
-			try recordingSession.setCategory(AVAudioSessionCategoryPlayAndRecord, with: .defaultToSpeaker )
+			let category = AVAudioSession.Category.playAndRecord
+			try recordingSession.setCategory(category)
 			try recordingSession.setActive(true)
 			recordingSession.requestRecordPermission { _ in
-				//[unowned self] allowed in
 				DispatchQueue.main.async {
 					// requestRecordPermission will ask the user for permission to record.
 					// in this block we should do something kind to the user when they say no.

--- a/TrailInsurance/NewClaimViewController+Uploading.swift
+++ b/TrailInsurance/NewClaimViewController+Uploading.swift
@@ -50,7 +50,7 @@ extension NewClaimViewController {
 		let alert = UIAlertController(title: nil, message: "Submitting Claim", preferredStyle: .alert)
 		let loadingModal = UIActivityIndicatorView(frame: CGRect(x: 10, y: 5, width: 50, height: 50))
 		loadingModal.hidesWhenStopped = true
-		loadingModal.activityIndicatorViewStyle = .gray
+		loadingModal.style = .gray
 		loadingModal.startAnimating()
 		alert.view.addSubview(loadingModal)
 		present(alert, animated: true, completion: nil)
@@ -123,8 +123,8 @@ extension NewClaimViewController {
 	///
 	/// - Parameter caseID: The ID of the case that is being modified.
 	private func uploadMapImage(forCaseID caseID: String) {
-		let options = MKMapSnapshotOptions()
-		let region = MKCoordinateRegionMakeWithDistance(mapView.centerCoordinate, regionRadius, regionRadius)
+		let options = MKMapSnapshotter.Options()
+		let region = MKCoordinateRegion.init(center: mapView.centerCoordinate, latitudinalMeters: regionRadius, longitudinalMeters: regionRadius)
 		options.region = region
 		options.scale = UIScreen.main.scale
 		options.size = CGSize(width: 800, height: 800)

--- a/TrailInsurance/OpenClaimsTableViewController.swift
+++ b/TrailInsurance/OpenClaimsTableViewController.swift
@@ -24,6 +24,10 @@ class OpenClaimsTableViewController: UITableViewController {
 		}
 	}
 
+	@IBAction func logout(_ sender: Any) {
+		UserAccountManager.shared.logout()
+	}
+	
 	private let dataSource = ObjectListDataSource(soqlQuery: "SELECT Id, Subject, CaseNumber FROM Case WHERE Status != 'Closed' ORDER BY CaseNumber DESC", cellReuseIdentifier: "CasePrototype") { record, cell in
 		let subject = record["Subject"] as? String ?? ""
 		let caseNumber = record["CaseNumber"] as? String ?? ""
@@ -38,7 +42,7 @@ class OpenClaimsTableViewController: UITableViewController {
 		self.tableView.activityIndicatorView.startAnimating()
 		self.tableView.dataSource = self.dataSource
 		self.refreshControl = UIRefreshControl()
-		refreshControl?.addTarget(self.dataSource, action: #selector(self.dataSource.fetchData), for: UIControlEvents.valueChanged)
+		refreshControl?.addTarget(self.dataSource, action: #selector(self.dataSource.fetchData), for: UIControl.Event.valueChanged)
 		self.tableView.addSubview(refreshControl!)
 		self.dataSource.fetchData()
 	}

--- a/TrailInsurance/RestClient+NewClaim.swift
+++ b/TrailInsurance/RestClient+NewClaim.swift
@@ -148,7 +148,7 @@ extension RestClient {
 	///   - caseID: The ID of the case to which the attachment is to be added.
 	/// - Returns: The new request.
 	func requestForCreatingImageAttachment(from image: UIImage, relatingToCaseID caseID: String) -> RestRequest {
-		let imageData = UIImagePNGRepresentation(image.resizedByHalf())!
+		let imageData = image.resizedByHalf().pngData()!
 		let fileName = UUID().uuidString + ".png"
 		return self.requestForCreatingAttachment(from: imageData, withFileName: fileName, relatingToCaseID: caseID)
 	}

--- a/TrailInsurance/UIView+loading.swift
+++ b/TrailInsurance/UIView+loading.swift
@@ -18,7 +18,7 @@ extension UIView {
 				return activityIndicatorView
 			} else {
 				let activityIndicatorView = UIActivityIndicatorView(frame: CGRect(x: 0, y: 0, width: 40, height: 40))
-				activityIndicatorView.activityIndicatorViewStyle = .whiteLarge
+				activityIndicatorView.style = .whiteLarge
 				activityIndicatorView.color = .gray
 				activityIndicatorView.center = CGPoint(x: self.bounds.size.width/2, y: self.bounds.size.height/2) //center
 				activityIndicatorView.hidesWhenStopped = true

--- a/TrailInsurance/main.swift
+++ b/TrailInsurance/main.swift
@@ -28,10 +28,7 @@ import SalesforceSDKCore
 
 UIApplicationMain(
     CommandLine.argc,
-    UnsafeMutableRawPointer(CommandLine.unsafeArgv)
-        .bindMemory(
-            to: UnsafeMutablePointer<Int8>.self,
-            capacity: Int(CommandLine.argc)),
+    CommandLine.unsafeArgv,
     NSStringFromClass(SFApplication.self),
     NSStringFromClass(AppDelegate.self)
 )


### PR DESCRIPTION
Before you is a pull request containing two things:

1. upgraded syntax to swift 5
2. the addition of a logout button, (and accompanying IBAction).  

In the creation of the last PR, it became evident that the community setup work is a bit much for widespread adoption of this app as a sample. As such, and to support several TDX / WWDC initiatives this app is in the process of having a trialforce org template created. Included in this PR, is the removal of a quick action from the metadata for case object. Scratch orgs *have* this quick action. Dev orgs do not. (no idea why) but removing that quick action line works.

Please limit your review to the IOS code, and to the changes therein. 